### PR TITLE
Rename blocking to async

### DIFF
--- a/htdocs/docs/rfn.lib.doc
+++ b/htdocs/docs/rfn.lib.doc
@@ -550,14 +550,14 @@ objects //o_1//, through //o_n//, as many as specified."
      fork : {
         input: [ { "func" : "F" } ],
         output : "0",
-        desc : "returns immediately and executes a blocking function in the background"
+        desc : "returns immediately and executes an async function in the background"
      },
 
      shotgun : {
         blocking : true,
         input: [ { "funcs" : "l" } ],
         output : "0",
-        desc : "executes a list of blocking functions in parallel, returns when they've all completed"
+        desc : "executes a list of async functions in parallel, returns when they've all completed"
      }
     
 

--- a/libpub/pub3lib.T
+++ b/libpub/pub3lib.T
@@ -284,7 +284,9 @@ namespace pub3 {
   ptr<const expr_t>
   patterned_fn_blocking_t::v_eval_1 (eval_t *e, const margs_t &) const {
 #ifdef SFS_DEBUG
-    strbuf b ("\"%s\" cannot be called in a non-blocking context.",
+    strbuf b ("async function \"%s\" cannot be called from a synchronous "
+              "context. The calling function must be called with asterisks: "
+              "fn(* args... *) throughout the callstack.",
               _name.cstr());
     report_error (e, b);
 #endif

--- a/librfn/sync.T
+++ b/librfn/sync.T
@@ -50,8 +50,8 @@ fork_t::v_eval_2 (publish_t *pub, const vec<arg_t> &args) const
 
 //-----------------------------------------------------------------------
 
-const str fork_t::DOCUMENTATION = R"*(returns immediately and executes a
-blocking function in the background
+const str fork_t::DOCUMENTATION = R"*(returns immediately and executes an
+async function in the background
 
 @param {function} f)*";
 
@@ -144,7 +144,7 @@ shotgun_t::v_pub_to_val_2 (eval_t *e, const checked_args_t &args, cxev_t ev)
 
 //-----------------------------------------------------------------------
 
-const str shotgun_t::DOCUMENTATION = R"*(executes a list of blocking functions
+const str shotgun_t::DOCUMENTATION = R"*(executes a list of async functions
 in parallel, returns when they've all completed
 
 @param {list} funcs

--- a/test/pub/blocking_call_warn.error
+++ b/test/pub/blocking_call_warn.error
@@ -1,1 +1,1 @@
-okws-pub3[eval]: blocking_call_warn.pub:1: "sleep" cannot be called in a non-blocking context.
+okws-pub3[eval]: blocking_call_warn.pub:1: "sleep" cannot be called from a synchronous context. It must be called with asterisks: "sleep(* delay *)".


### PR DESCRIPTION
One of the banes of my existence.

TODO: Improve error to point more directly to which function created the current synchronous context.